### PR TITLE
Replaced gksu with lxqt-sudo for debian package making - (Solves - #40)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,11 @@ addons:
   apt:
     update: true
 sudo: required
+dist: xenial
 git:
   depth: 22
 before_script:
-- sudo apt-get install devscripts debhelper
+- sudo apt-get install devscripts debhelper lxqt-sudo fakeroot
 script:
 - chmod +x debuild.sh
 - "./debuild.sh |& tee log.txt"

--- a/systemlock_0.1/debian/control
+++ b/systemlock_0.1/debian/control
@@ -2,7 +2,7 @@ Source: systemlock
 Section: x11
 Priority: extra
 Maintainer: x-mario <vanhonit@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), python(>=2.6), nautilus-admin
+Build-Depends: debhelper (>= 8.0.0), python(>=2.6), lxqt-sudo
 Standards-Version: 3.9.2
 Homepage: http://mbm.vn
 


### PR DESCRIPTION
### Short description
This replaces gksu with lxqt-sudo for the making of the systemlock package
I have:
- [x] There is a corresponding issue for this pull request.
- [x] Mentioned the Issue number in the pull request commit message `Fixes #<number> commit message`

### For the reviewers
I have:
- [ ] Reviewed this pull request as an authorized contributor.
- [ ] The reviewer is assigned to the pull request.

Fixes #40 